### PR TITLE
manually removes minima gem from gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GEM
     coffee-script-source (1.11.1)
     colorator (1.1.0)
     colorize (0.8.1)
-    commonmarker (0.17.7)
+    commonmarker (0.17.7.1)
       ruby-enum (~> 0.5)
     concurrent-ruby (1.0.5)
     em-websocket (0.5.1)
@@ -85,12 +85,12 @@ GEM
     html-pipeline (2.7.1)
       activesupport (>= 2)
       nokogiri (>= 1.4)
-    html-proofer (3.7.5)
+    html-proofer (3.7.6)
       activesupport (>= 4.2, < 6.0)
       addressable (~> 2.3)
       colorize (~> 0.8)
       mercenary (~> 0.3.2)
-      nokogiri (~> 1.7)
+      nokogiri (~> 1.8.1)
       parallel (~> 1.3)
       typhoeus (~> 0.7)
       yell (~> 2.0)
@@ -211,15 +211,15 @@ GEM
     mini_portile2 (2.3.0)
     minima (2.1.1)
       jekyll (~> 3.3)
-    minitest (5.10.3)
+    minitest (5.11.1)
     multipart-post (2.0.0)
     net-dns (0.8.0)
     nokogiri (1.8.1)
       mini_portile2 (~> 2.3.0)
-    octokit (4.7.0)
+    octokit (4.8.0)
       sawyer (~> 0.8.0, >= 0.5.3)
-    parallel (1.12.0)
-    pathutil (0.16.0)
+    parallel (1.12.1)
+    pathutil (0.16.1)
       forwardable-extended (~> 2.6)
     public_suffix (2.0.5)
     rb-fsevent (0.10.2)
@@ -230,7 +230,7 @@ GEM
       i18n
     rubyzip (1.2.1)
     safe_yaml (1.0.4)
-    sass (3.5.3)
+    sass (3.5.5)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -255,7 +255,6 @@ DEPENDENCIES
   github-pages
   hawkins
   html-proofer
-  minima (~> 2.0)
 
 BUNDLED WITH
    1.16.0


### PR DESCRIPTION
After removing the minima gem from the `Gemfile`, `scripts/server` refused to run, even after destroying the VM.

The following was the received error:
``` bash
You have deleted from the Gemfile:
* minima (~> 2.0)
ERROR: Service 'jekyll' failed to build: The command '/bin/sh -c bundle install' returned a non-zero code: 16
```

I would have expected bundle install to run and regenerate the `Gemfile.lock` file, but my understanding of bundle is hand-wavy at best. By manually removing the minima dependency from `Gemfile.lock` the command above works as expected.