### PR TITLE
change to correct mailchimp form, remove apply btns for nonsession

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -8,7 +8,13 @@
         <a href="/about">About</a>
         <a href="/projects">Projects</a>
         <a href="/faq">FAQ</a>
-        <a href="#" class="btn btn-primary">Apply</a>
+        {% if site.fellowship_in_session %}
+          <a href="#" class="btn btn-primary">Apply</a>
+        {% else %}
+          <a href="#job-alert-modal" class="btn btn-ghost form-modal-open" rel="modal:open">
+            Receive alerts
+          </a>
+        {% endif %}
       </nav>
     </div>
   </div>

--- a/_includes/hero-post.html
+++ b/_includes/hero-post.html
@@ -11,7 +11,9 @@
         </span>
         {{ page.title }}
       </h1>
-      <a href="#" class="btn btn-primary">Apply now</a>
+      {% if site.fellowship_in_session %}
+        <a href="#" class="btn btn-primary">Apply</a>
+      {% endif %}
     </div>
   </div>
 </header>

--- a/_includes/hero.html
+++ b/_includes/hero.html
@@ -10,11 +10,17 @@
 
       {% if page.hero.buttons %}
       <div class="hero-actions">
-        {% for button in page.hero.buttons %}
-          <a href="{{ button.button-link }}" class="btn {{ button.button-type }}">
-            {{ button.button-label }}
+        {% if site.fellowship_in_session %}
+          {% for button in page.hero.buttons %}
+            <a href="{{ button.button-link }}" class="btn {{ button.button-type }}">
+              {{ button.button-label }}
+            </a>
+          {% endfor %}
+        {% else %}
+          <a href="#job-alert-modal" class="btn btn-ghost form-modal-open" rel="modal:open">
+            Sign up for alerts
           </a>
-        {% endfor %}
+        {% endif %}
       </div>
       {% endif %}
     </div>

--- a/_includes/job-form.html
+++ b/_includes/job-form.html
@@ -3,38 +3,46 @@
     <h3 class="color-white">Receive Alerts</h3>
     <p>Sign up to receive email notifications for when we open next year’s fellowship session. Don’t worry, you’ll only hear from us if it’s about the Azavea open source fellowship</p>
   </div>
-  <form action="https://azavea.us1.list-manage.com/subscribe/post?u=61da999c9897859f1c1fff262&amp;id=517ce57b5e" method="post" id="mc-embedded-subscribe-form" name="mc-embedded-subscribe-form" target="_blank" novalidate>
+  <form action="https://azavea.us1.list-manage.com/subscribe/post?u=61da999c9897859f1c1fff262&amp;id=7bb468c9c1" method="post"  name="mc-embedded-subscribe-form" target="_blank" novalidate>
     <div class="form-group">
-      <label for="mce-EMAIL-modal">Email Address <span>*</span>
+      <label>First Name <span>*</span>
+        <input type="text" value="" name="FNAME" class="required">
       </label>
-      <input type="email" value="" name="EMAIL" class="required email" id="mce-EMAIL-modal">
     </div>
     <div class="form-group">
-      <label for="mce-FNAME">First Name <span>*</span>
+      <label>Last Name <span>*</span>
+        <input type="text" value="" name="LNAME" class="required">
       </label>
-      <input type="text" value="" name="FNAME" class="required" id="mce-FNAME">
     </div>
     <div class="form-group">
-      <label for="mce-LNAME">Last Name <span>*</span>
+      <label>Email Address <span>*</span>
+        <input type="email" value="" name="EMAIL" class="required email">
       </label>
-      <input type="text" value="" name="LNAME" class="required" id="mce-LNAME">
     </div>
-    <div class="form-group disabled">
-      <div class="hide" aria-hidden>
-        <input checked type="checkbox" value="128" name="group[6293][128]" id="mce-group[6293]-6293-7">
-      </div>
-      <label for="mce-group[6293]-6293-7" disabled>Department</label>
-      <select name="group[6293][128]" id="mce-group[6293]-6293-7" disabled>
-        <option value="mce-group[6293]-6293-7" selected>Fellowships</option>
-      </select>
+    <div class="form-group check-list">
+      <label>I'm interested in:</label>
+      <label class="checkbox">
+        <input type="checkbox" value="1" name="group[6297][1]">
+        <span></span>
+        becoming an Azavea Fellow
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" value="2" name="group[6297][2]">
+        <span></span>
+        helping to promote the program
+      </label>
+      <label class="checkbox">
+        <input type="checkbox" value="4" name="group[6297][4]">
+        <span></span>
+        sponsoring an Azavea Fellow
+      </label>
     </div>
     <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
     <div style="position: absolute; left: -5000px;" aria-hidden="true">
-      <input type="text" name="b_61da999c9897859f1c1fff262_517ce57b5e" tabindex="-1" value="">
+      <input type="text" name="b_61da999c9897859f1c1fff262_7bb468c9c1" tabindex="-1" value="">
     </div>
     <div class="btn-group">
       <input type="submit" value="Subscribe" name="subscribe" id="mc-embedded-subscribe" class="btn">
-      <a href="#close" rel="modal:close" class="btn btn-secondary close-button">Close</a>
     </div>
   </form>
 </div>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -29,7 +29,13 @@
           {% endif %}>
           FAQ
         </a>
-        <a href="#" class="btn btn-primary">Apply</a>
+        {% if site.fellowship_in_session %}
+          <a href="#" class="btn btn-primary">Apply</a>
+        {% else %}
+          <a href="#job-alert-modal" class="btn btn-ghost form-modal-open" rel="modal:open">
+            Receive alerts
+          </a>
+        {% endif %}
       </nav>
     </div>
   </div>

--- a/_sass/components/_button.scss
+++ b/_sass/components/_button.scss
@@ -41,7 +41,7 @@
   user-select: none;
   background: #fff;
   color: $base;
-  transition: .2s ease-in-out box-shadow;
+  transition: .2s ease-in-out box-shadow, .2s ease-in-out color, .2s ease-in-out background;
   text-transform: uppercase;
 
   &:hover, &.hover,

--- a/_sass/components/_call-to-action.scss
+++ b/_sass/components/_call-to-action.scss
@@ -20,10 +20,6 @@ section.join-us {
       padding: 2rem;
     }
 
-    .btn-group {
-      margin-left: auto;
-    }
-
     .close-button {
       speak: none;
       display: none;

--- a/_sass/components/_form.scss
+++ b/_sass/components/_form.scss
@@ -54,6 +54,65 @@ label {
   margin-bottom: 5px;
   font-weight: 400;
   font-size: 1.4rem;
+
+  input {
+    margin-top: .5rem;
+  }
+}
+
+.checkbox {
+  position: relative;
+  padding-left: 2.5rem;
+
+  input[type="checkbox"] {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    width: 100%;
+    height: 100%;
+    background: none;
+    padding: 0;
+    z-index: 10;
+    
+    &:checked + span {
+      background: $primary;
+    }
+
+    &:checked + span:after {
+      transform: scale(1);
+    }
+
+    &:focus + span {
+      box-shadow: 0 0 0 2px rgba($white, .5);
+    }
+  }
+
+  span {
+    position: absolute;
+    top: 0;
+    left: 0;
+    margin: 0;
+    display: block;
+    width: 1.7rem;
+    height: 1.7rem;
+    background: $white;
+    border: none;
+    color: $base;
+    border-radius: 2px;
+    transition: .2s ease-in-out background;
+
+    &:after {
+      content: '✕';
+      color: $white;
+      position: absolute;
+      left: 3px;
+      top: 0px;
+      transform: scale(0);
+      transition: .2s ease-in-out transform;
+    }
+  }
 }
 
 .form-group {

--- a/_sass/components/_job-form.scss
+++ b/_sass/components/_job-form.scss
@@ -6,13 +6,30 @@
     justify-content: space-between;
   }
 
-  .form-group,
-  .btn-group {
+  .form-group {
     flex-basis: 48%;
 
     @media (max-width: 900px) {
       flex-basis: 100%;
       width: 100%;
+    }
+  }
+
+  .check-list {
+    flex-basis: 100%;
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+
+    > label {
+      flex: none;
+      width: 100%;
+    }
+
+    .checkbox {
+      display: flex;
+      flex: 1;
+      align-items: center;
     }
   }
 

--- a/_sass/components/_modal.scss
+++ b/_sass/components/_modal.scss
@@ -15,6 +15,5 @@
   box-shadow: none;
 
   a.close-modal {
-    display: none;
   }
 }

--- a/_sass/pages/_secondary.scss
+++ b/_sass/pages/_secondary.scss
@@ -6,6 +6,10 @@ body.secondary {
   .navbar nav a:not(.btn) {
     color: $black;
   }
+
+  .navbar .btn-ghost {
+    color: $black;
+  }
   
   .inner-content > {
     h1, h2, h3, h4, h5, h6,


### PR DESCRIPTION
#### Overview
1. Replaced the job notification mailchimp form in favor or the fellowship mailchimp form.
    - fixes #25 
2. Added logic to replace Apply buttons when fellowship not in session.
    - Homepage hero apply button logic to replace with receive alert modal button
    - Main Navbar and footer navbar apply button logic to replace with receive alert modal button
    - Removed apply button from individual project hero
    - fixes #23 


#### Demo
**1. Mailchimp update** 
<img width="837" alt="screen shot 2018-01-19 at 2 40 18 pm" src="https://user-images.githubusercontent.com/1928955/35168401-cd515f42-fd26-11e7-9cb9-a8fb56b63432.png">

**2. Receive Alert buttons**
<img width="1198" alt="screen shot 2018-01-19 at 2 25 32 pm" src="https://user-images.githubusercontent.com/1928955/35168211-19e00abc-fd26-11e7-8f6a-4bc2f28f445a.png">


#### Testing
- open `_config.yml`
- change `fellowship_in_session` from `true` to `false`
- start server