### PR TITLE
Add project page for lambda tile generator

### DIFF
--- a/_projects/lambda_tiles.md
+++ b/_projects/lambda_tiles.md
@@ -51,6 +51,9 @@ on demand.
 
 - Reimplement Lambnik in Node.js
 
+The Python bindings for Mapnik are incomplete and not actively maintained.  The Node version is
+more complete, including support for vector tiles.
+
 #### Coding Phase 2
 
 - Make raster tile styling configurable (load the Mapnik XML from a configurable source)

--- a/_projects/lambda_tiles.md
+++ b/_projects/lambda_tiles.md
@@ -54,10 +54,15 @@ on demand.
 The Python bindings for Mapnik are incomplete and not actively maintained.  The Node version is
 more complete, including support for vector tiles.
 
+Outcome: a proof-of-concept raster tile source serving custom data via Node on Lambda.
+
 #### Coding Phase 2
 
 - Make raster tile styling configurable (load the Mapnik XML from a configurable source)
 - Streamline and document the deployment process
+
+Outcome: a basic raster tile source for custom data that could be added to a project in
+lieu of Windshaft.
 
 #### Coding Phase 3
 
@@ -67,3 +72,5 @@ more complete, including support for vector tiles.
 - Create a static HTML demo page
    - Using Mapbox GL JS
    - Possibly also using Leaflet
+
+Outcome: a proof-of-concept demo of a vector-tile-based interactive map of custom data.

--- a/_projects/lambda_tiles.md
+++ b/_projects/lambda_tiles.md
@@ -1,0 +1,66 @@
+---
+published: false
+
+title: "Lambda Tilegarden" # project title inside quotes
+excerpt: "Lambda-based raster and vector tile generation from PostGIS data" # shows on project list page
+seo_description: "Render Mapnik raster tiles or Mapbox vector tiles from a PostGIS data source using Lambda" # goes in project meta description
+
+# project attributes
+requirements: # bullet list of requirements – one requirement per line – follow below format
+  - "Python experience"
+  - "Javascript experience"
+  - "Geospatial experience preferred"
+
+tags: # one tag per line – spaces are allowed in tags – use tags other posts use
+  - "python"
+  - "nodejs"
+  - "AWS Lambda"
+  - "raster tiles"
+  - "vector tiles"
+
+difficulty: "medium" # easy, medium, hard – pick one
+
+mentors: # github username without the @ – example: designmatty
+  - "KlaasH"
+  - "mmcfarland"
+
+# This file uses Kramdown. See https://kramdown.gettalong.org/syntax.html for syntax
+---
+
+At Azavea, we frequently have custom map layers or features stored in PostGIS that we need to
+integrate into front-end visualizations and tools.  Tools like Windshaft and Geoserver can generate
+and format raster tiles, but require significant configuration and dedicated infrastructure.
+
+In addition, some of the work that requires dynamic server-side rendering of custom data into
+raster tiles could be avoided by taking advantage of the potential of vector tiles for client-side
+dynamic interactivity.
+
+The goal of this project is to create a configurable, adaptable, and fully open-source toolchain
+and demo implementation for using Lambda and a PostGIS data source to produce custom tiles
+on demand.
+
+### Milestones
+
+#### Preparation
+
+- Familiarization with [Lambnik](https://github.com/azavea/lambnik)
+- Familiarization with Mapnik styling and rendering
+- Deploy Lambnik and successfully run demo page
+
+#### Coding Phase 1
+
+- Reimplement Lambnik in Node.js
+
+#### Coding Phase 2
+
+- Make raster tile styling configurable (load the Mapnik XML from a configurable source)
+- Streamline and document the deployment process
+
+#### Coding Phase 3
+
+- Add vector tile generation
+- Pull layer spec from configurable source
+- Make styling configurable and fully open (i.e. not Mapbox-hosted)
+- Create a static HTML demo page
+   - Using Mapbox GL JS
+   - Possibly also using Leaflet


### PR DESCRIPTION
A project write-up based on the discussion about this with @CloudNiner and @mmcfarland last week.

I think I covered the pieces we discussed.  Not sure how much detail is the right amount, but this seems in line with the existing project pages.  Phase 3 has more pieces and more unknowns than the other two, but that seems OK, since we'd have a context for defining it better and the landscape might shift before that point anyway.

I gave it a jaunty name somewhat off the top of my head.  I couldn't think of a "lamb___" amalgamation that would fit the broader scope.